### PR TITLE
MI5-59 Dodavanje filtriranja na endpoint za dohvat transakcija

### DIFF
--- a/src/main/java/foi/air/szokpt/transactionmng/controllers/TransactionController.java
+++ b/src/main/java/foi/air/szokpt/transactionmng/controllers/TransactionController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 @RestController
@@ -32,9 +33,10 @@ public class TransactionController {
             @RequestParam(name = "card_brand", required = false) CardBrand cardBrand,
             @RequestParam(name = "trx_type", required = false) TrxType trxType,
             @RequestParam(required = false) @DateTimeFormat(pattern = "dd/MM/yyyy HH:mm:ss") LocalDateTime before,
-            @RequestParam(required = false) @DateTimeFormat(pattern = "dd/MM/yyyy HH:mm:ss") LocalDateTime after) {
+            @RequestParam(required = false) @DateTimeFormat(pattern = "dd/MM/yyyy HH:mm:ss") LocalDateTime after,
+            @RequestParam(required = false, name = "amount_greater_than") BigDecimal amountGreaterThan) {
         TransactionPageData transactionPageData = transactionService.getTransactions(
-                page, cardBrand, trxType, before, after);
+                page, cardBrand, trxType, before, after, amountGreaterThan);
         return ResponseEntity.status(HttpStatus.OK)
                 .body(ApiResponseUtil.successWithData("Transactions successfully fetched", transactionPageData));
     }

--- a/src/main/java/foi/air/szokpt/transactionmng/controllers/TransactionController.java
+++ b/src/main/java/foi/air/szokpt/transactionmng/controllers/TransactionController.java
@@ -34,9 +34,10 @@ public class TransactionController {
             @RequestParam(name = "trx_type", required = false) TrxType trxType,
             @RequestParam(required = false) @DateTimeFormat(pattern = "dd/MM/yyyy HH:mm:ss") LocalDateTime before,
             @RequestParam(required = false) @DateTimeFormat(pattern = "dd/MM/yyyy HH:mm:ss") LocalDateTime after,
-            @RequestParam(required = false, name = "amount_greater_than") BigDecimal amountGreaterThan) {
+            @RequestParam(required = false, name = "amount_greater_than") BigDecimal amountGreaterThan,
+            @RequestParam(required = false, name = "amount_less_than") BigDecimal amountLessThan) {
         TransactionPageData transactionPageData = transactionService.getTransactions(
-                page, cardBrand, trxType, before, after, amountGreaterThan);
+                page, cardBrand, trxType, before, after, amountGreaterThan, amountLessThan);
         return ResponseEntity.status(HttpStatus.OK)
                 .body(ApiResponseUtil.successWithData("Transactions successfully fetched", transactionPageData));
     }

--- a/src/main/java/foi/air/szokpt/transactionmng/controllers/TransactionController.java
+++ b/src/main/java/foi/air/szokpt/transactionmng/controllers/TransactionController.java
@@ -2,6 +2,7 @@ package foi.air.szokpt.transactionmng.controllers;
 
 import foi.air.szokpt.transactionmng.dtos.responses.ApiResponse;
 import foi.air.szokpt.transactionmng.dtos.responses.TransactionPageData;
+import foi.air.szokpt.transactionmng.enums.CardBrand;
 import foi.air.szokpt.transactionmng.services.TransactionService;
 import foi.air.szokpt.transactionmng.util.ApiResponseUtil;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,8 +23,10 @@ public class TransactionController {
     }
 
     @GetMapping("/transactions")
-    public ResponseEntity<ApiResponse<TransactionPageData>> getTransactions(@RequestParam(required = false) Integer page) {
-        TransactionPageData transactionPageData = transactionService.getTransactions(page);
+    public ResponseEntity<ApiResponse<TransactionPageData>> getTransactions(
+            @RequestParam(required = false) Integer page,
+            @RequestParam(name = "card_brand", required = false) CardBrand cardBrand) {
+        TransactionPageData transactionPageData = transactionService.getTransactions(page, cardBrand);
         return ResponseEntity.status(HttpStatus.OK)
                 .body(ApiResponseUtil.successWithData("Transactions successfully fetched", transactionPageData));
     }

--- a/src/main/java/foi/air/szokpt/transactionmng/controllers/TransactionController.java
+++ b/src/main/java/foi/air/szokpt/transactionmng/controllers/TransactionController.java
@@ -31,9 +31,10 @@ public class TransactionController {
             @RequestParam(required = false) Integer page,
             @RequestParam(name = "card_brand", required = false) CardBrand cardBrand,
             @RequestParam(name = "trx_type", required = false) TrxType trxType,
-            @RequestParam(required = false) @DateTimeFormat(pattern = "dd/MM/yyyy HH:mm:ss") LocalDateTime before) {
+            @RequestParam(required = false) @DateTimeFormat(pattern = "dd/MM/yyyy HH:mm:ss") LocalDateTime before,
+            @RequestParam(required = false) @DateTimeFormat(pattern = "dd/MM/yyyy HH:mm:ss") LocalDateTime after) {
         TransactionPageData transactionPageData = transactionService.getTransactions(
-                page, cardBrand, trxType, before);
+                page, cardBrand, trxType, before, after);
         return ResponseEntity.status(HttpStatus.OK)
                 .body(ApiResponseUtil.successWithData("Transactions successfully fetched", transactionPageData));
     }

--- a/src/main/java/foi/air/szokpt/transactionmng/controllers/TransactionController.java
+++ b/src/main/java/foi/air/szokpt/transactionmng/controllers/TransactionController.java
@@ -3,6 +3,7 @@ package foi.air.szokpt.transactionmng.controllers;
 import foi.air.szokpt.transactionmng.dtos.responses.ApiResponse;
 import foi.air.szokpt.transactionmng.dtos.responses.TransactionPageData;
 import foi.air.szokpt.transactionmng.enums.CardBrand;
+import foi.air.szokpt.transactionmng.enums.TrxType;
 import foi.air.szokpt.transactionmng.services.TransactionService;
 import foi.air.szokpt.transactionmng.util.ApiResponseUtil;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,8 +26,10 @@ public class TransactionController {
     @GetMapping("/transactions")
     public ResponseEntity<ApiResponse<TransactionPageData>> getTransactions(
             @RequestParam(required = false) Integer page,
-            @RequestParam(name = "card_brand", required = false) CardBrand cardBrand) {
-        TransactionPageData transactionPageData = transactionService.getTransactions(page, cardBrand);
+            @RequestParam(name = "card_brand", required = false) CardBrand cardBrand,
+            @RequestParam(name = "trx_type", required = false) TrxType trxType) {
+        TransactionPageData transactionPageData = transactionService.getTransactions(
+                page, cardBrand, trxType);
         return ResponseEntity.status(HttpStatus.OK)
                 .body(ApiResponseUtil.successWithData("Transactions successfully fetched", transactionPageData));
     }

--- a/src/main/java/foi/air/szokpt/transactionmng/controllers/TransactionController.java
+++ b/src/main/java/foi/air/szokpt/transactionmng/controllers/TransactionController.java
@@ -7,11 +7,14 @@ import foi.air.szokpt.transactionmng.enums.TrxType;
 import foi.air.szokpt.transactionmng.services.TransactionService;
 import foi.air.szokpt.transactionmng.util.ApiResponseUtil;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDateTime;
 
 @RestController
 public class TransactionController {
@@ -27,9 +30,10 @@ public class TransactionController {
     public ResponseEntity<ApiResponse<TransactionPageData>> getTransactions(
             @RequestParam(required = false) Integer page,
             @RequestParam(name = "card_brand", required = false) CardBrand cardBrand,
-            @RequestParam(name = "trx_type", required = false) TrxType trxType) {
+            @RequestParam(name = "trx_type", required = false) TrxType trxType,
+            @RequestParam(required = false) @DateTimeFormat(pattern = "dd/MM/yyyy HH:mm:ss") LocalDateTime before) {
         TransactionPageData transactionPageData = transactionService.getTransactions(
-                page, cardBrand, trxType);
+                page, cardBrand, trxType, before);
         return ResponseEntity.status(HttpStatus.OK)
                 .body(ApiResponseUtil.successWithData("Transactions successfully fetched", transactionPageData));
     }

--- a/src/main/java/foi/air/szokpt/transactionmng/converters/CardBrandConverter.java
+++ b/src/main/java/foi/air/szokpt/transactionmng/converters/CardBrandConverter.java
@@ -1,0 +1,22 @@
+package foi.air.szokpt.transactionmng.converters;
+
+import foi.air.szokpt.transactionmng.enums.CardBrand;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CardBrandConverter extends EnumConverter<CardBrand> {
+    @Override
+    public CardBrand convert(String source) {
+        CardBrand cardBrand = CardBrand.getByName(source.toLowerCase());
+        return cardBrand == null ? getInvalid() : cardBrand;
+    }
+
+    protected CardBrand getInvalid() {
+        return CardBrand.Invalid;
+    }
+
+    protected Class<CardBrand> getEnumType() {
+        return CardBrand.class;
+    }
+
+}

--- a/src/main/java/foi/air/szokpt/transactionmng/converters/EnumConverter.java
+++ b/src/main/java/foi/air/szokpt/transactionmng/converters/EnumConverter.java
@@ -1,12 +1,16 @@
 package foi.air.szokpt.transactionmng.converters;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.core.convert.converter.Converter;
 
 public abstract class EnumConverter<T extends Enum<T>> implements Converter<String, T> {
+    private static final Logger log = LoggerFactory.getLogger(EnumConverter.class);
+
     @Override
     public T convert(String source) {
         try {
-            return Enum.valueOf(getEnumType(), source);
+            return Enum.valueOf(getEnumType(), source.toLowerCase());
         } catch (IllegalArgumentException | NullPointerException e) {
             return getInvalid();
         }

--- a/src/main/java/foi/air/szokpt/transactionmng/converters/EnumConverter.java
+++ b/src/main/java/foi/air/szokpt/transactionmng/converters/EnumConverter.java
@@ -1,0 +1,18 @@
+package foi.air.szokpt.transactionmng.converters;
+
+import org.springframework.core.convert.converter.Converter;
+
+public abstract class EnumConverter<T extends Enum<T>> implements Converter<String, T> {
+    @Override
+    public T convert(String source) {
+        try {
+            return Enum.valueOf(getEnumType(), source);
+        } catch (IllegalArgumentException | NullPointerException e) {
+            return getInvalid();
+        }
+    }
+
+    protected abstract T getInvalid();
+
+    protected abstract Class<T> getEnumType();
+}

--- a/src/main/java/foi/air/szokpt/transactionmng/converters/TrxTypeConverter.java
+++ b/src/main/java/foi/air/szokpt/transactionmng/converters/TrxTypeConverter.java
@@ -1,0 +1,16 @@
+package foi.air.szokpt.transactionmng.converters;
+
+import foi.air.szokpt.transactionmng.enums.TrxType;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TrxTypeConverter extends EnumConverter<TrxType> {
+
+    protected TrxType getInvalid() {
+        return TrxType.invalid;
+    }
+
+    protected Class<TrxType> getEnumType() {
+        return TrxType.class;
+    }
+}

--- a/src/main/java/foi/air/szokpt/transactionmng/entities/Transaction.java
+++ b/src/main/java/foi/air/szokpt/transactionmng/entities/Transaction.java
@@ -7,7 +7,7 @@ import foi.air.szokpt.transactionmng.enums.TrxType;
 import jakarta.persistence.*;
 
 import java.math.BigDecimal;
-import java.sql.Timestamp;
+import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "transactions")
@@ -39,7 +39,7 @@ public class Transaction {
 
     @Column(name = "transaction_timestamp", nullable = false)
     @JsonFormat(pattern = "dd/MM/yyyy HH:mm:ss")
-    private Timestamp transactionTimestamp;
+    private LocalDateTime transactionTimestamp;
 
     @Column(name = "masked_pan", nullable = false)
     private String maskedPan;
@@ -53,11 +53,12 @@ public class Transaction {
     @Column(name = "processed", nullable = false)
     private Boolean processed;
 
-    public Transaction() {}
+    public Transaction() {
+    }
 
     public Transaction(BigDecimal amount, String currency,
                        TrxType trxType, Integer installmentsNumber, InstallmentsCreditor installmentsCreditor,
-                       CardBrand cardBrand, Timestamp transactionTimestamp,
+                       CardBrand cardBrand, LocalDateTime transactionTimestamp,
                        String maskedPan, Boolean pinUsed, String responseCode, Boolean processed) {
         this.amount = amount;
         this.currency = currency;
@@ -112,12 +113,12 @@ public class Transaction {
         this.installmentsNumber = installmentsNumber;
     }
 
-    public InstallmentsCreditor getInstallmentsCreditor() {
-        return installmentsCreditor;
-    }
-
     public void setInstallmentsNumber(InstallmentsCreditor installmentsCreditor) {
         this.installmentsCreditor = installmentsCreditor;
+    }
+
+    public InstallmentsCreditor getInstallmentsCreditor() {
+        return installmentsCreditor;
     }
 
     public CardBrand getCardBrand() {
@@ -128,11 +129,11 @@ public class Transaction {
         this.cardBrand = cardBrand;
     }
 
-    public Timestamp getTransactionTimestamp() {
+    public LocalDateTime getTransactionTimestamp() {
         return transactionTimestamp;
     }
 
-    public void setTransactionTimestamp(Timestamp transactionTimestamp) {
+    public void setTransactionTimestamp(LocalDateTime transactionTimestamp) {
         this.transactionTimestamp = transactionTimestamp;
     }
 

--- a/src/main/java/foi/air/szokpt/transactionmng/enums/CardBrand.java
+++ b/src/main/java/foi/air/szokpt/transactionmng/enums/CardBrand.java
@@ -1,10 +1,31 @@
 package foi.air.szokpt.transactionmng.enums;
 
 public enum CardBrand {
-    Visa,
-    MasterCard,
-    Diners,
-    Discover,
-    Maestro;
+    Visa("visa"),
+    MasterCard("mastercard"),
+    Diners("diners"),
+    Discover("discover"),
+    Maestro("maestro"),
+    Invalid("invalid");
+
+    private final String name;
+
+    CardBrand(String name) {
+        this.name = name;
+    }
+
+    public static CardBrand getByName(String name) {
+        for (CardBrand cardBrand : values()) {
+            if (cardBrand.getName().equals(name)) {
+                return cardBrand;
+            }
+        }
+        return null;
+    }
+
+    public String getName() {
+        return name;
+    }
+
 }
 

--- a/src/main/java/foi/air/szokpt/transactionmng/enums/TrxType.java
+++ b/src/main/java/foi/air/szokpt/transactionmng/enums/TrxType.java
@@ -6,5 +6,6 @@ public enum TrxType {
     void_sale,
     void_refund,
     reversal_sale,
-    reversal_refund
+    reversal_refund,
+    invalid
 }

--- a/src/main/java/foi/air/szokpt/transactionmng/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/foi/air/szokpt/transactionmng/exceptions/GlobalExceptionHandler.java
@@ -1,0 +1,22 @@
+package foi.air.szokpt.transactionmng.exceptions;
+
+import foi.air.szokpt.transactionmng.dtos.responses.ApiResponse;
+import foi.air.szokpt.transactionmng.util.ApiResponseUtil;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+import java.time.LocalDateTime;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ApiResponse<Object>> handleTypeMismatchException(MethodArgumentTypeMismatchException ex) {
+        if (ex.getRequiredType() != null && ex.getRequiredType().equals(LocalDateTime.class)) {
+            return ResponseEntity.badRequest().body(ApiResponseUtil.failure("Invalid date format"));
+        }
+        return ResponseEntity.badRequest().body(ApiResponseUtil.failure("Invalid parameter value"));
+    }
+}

--- a/src/main/java/foi/air/szokpt/transactionmng/repositories/TransactionRepository.java
+++ b/src/main/java/foi/air/szokpt/transactionmng/repositories/TransactionRepository.java
@@ -4,9 +4,12 @@ import foi.air.szokpt.transactionmng.entities.Transaction;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.lang.NonNull;
 
-public interface TransactionRepository extends JpaRepository<Transaction, Integer> {
+public interface TransactionRepository extends JpaRepository<Transaction, Integer>,
+        JpaSpecificationExecutor<Transaction> {
     @NonNull
     Page<Transaction> findAll(@NonNull Pageable pageable);
+
 }

--- a/src/main/java/foi/air/szokpt/transactionmng/services/TransactionService.java
+++ b/src/main/java/foi/air/szokpt/transactionmng/services/TransactionService.java
@@ -6,16 +6,20 @@ import foi.air.szokpt.transactionmng.enums.CardBrand;
 import foi.air.szokpt.transactionmng.enums.TrxType;
 import foi.air.szokpt.transactionmng.repositories.TransactionRepository;
 import foi.air.szokpt.transactionmng.specs.TransactionSpecs;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
 public class TransactionService {
+    private static final Logger log = LoggerFactory.getLogger(TransactionService.class);
     final int pageSize = 15;
     private final TransactionRepository transactionRepository;
 
@@ -26,10 +30,12 @@ public class TransactionService {
     public TransactionPageData getTransactions(
             Integer page,
             CardBrand cardBrand,
-            TrxType trxType) {
+            TrxType trxType,
+            LocalDateTime before) {
         Specification<Transaction> spec = Specification
                 .where(TransactionSpecs.hasCardBrand(cardBrand))
-                .and(TransactionSpecs.hasTrxType(trxType));
+                .and(TransactionSpecs.hasTrxType(trxType))
+                .and(TransactionSpecs.beforeDateTime(before));
         if (page == null) return getAllTransactions(spec);
         return getTransactionsByPage(page, pageSize, spec);
     }

--- a/src/main/java/foi/air/szokpt/transactionmng/services/TransactionService.java
+++ b/src/main/java/foi/air/szokpt/transactionmng/services/TransactionService.java
@@ -14,6 +14,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -32,12 +33,14 @@ public class TransactionService {
             CardBrand cardBrand,
             TrxType trxType,
             LocalDateTime before,
-            LocalDateTime after) {
+            LocalDateTime after,
+            BigDecimal amountGreaterThan) {
         Specification<Transaction> spec = Specification
                 .where(TransactionSpecs.hasCardBrand(cardBrand))
                 .and(TransactionSpecs.hasTrxType(trxType))
                 .and(TransactionSpecs.beforeDateTime(before))
-                .and(TransactionSpecs.afterDateTime(after));
+                .and(TransactionSpecs.afterDateTime(after)
+                        .and(TransactionSpecs.amountGreaterThan(amountGreaterThan)));
         if (page == null) return getAllTransactions(spec);
         return getTransactionsByPage(page, pageSize, spec);
     }

--- a/src/main/java/foi/air/szokpt/transactionmng/services/TransactionService.java
+++ b/src/main/java/foi/air/szokpt/transactionmng/services/TransactionService.java
@@ -2,38 +2,49 @@ package foi.air.szokpt.transactionmng.services;
 
 import foi.air.szokpt.transactionmng.dtos.responses.TransactionPageData;
 import foi.air.szokpt.transactionmng.entities.Transaction;
+import foi.air.szokpt.transactionmng.enums.CardBrand;
 import foi.air.szokpt.transactionmng.repositories.TransactionRepository;
+import foi.air.szokpt.transactionmng.specs.TransactionSpecs;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 
 @Service
 public class TransactionService {
-    private final TransactionRepository transactionRepository;
     final int pageSize = 15;
+    private final TransactionRepository transactionRepository;
 
     public TransactionService(TransactionRepository transactionRepository) {
         this.transactionRepository = transactionRepository;
     }
 
-    public TransactionPageData getTransactions(Integer page) {
-        if (page == null) return getAllTransactions();
-        return getTransactionsByPage(page, pageSize);
+    public TransactionPageData getTransactions(Integer page, CardBrand cardBrand) {
+        Specification<Transaction> spec = Specification
+                .where(TransactionSpecs.hasCardBrand(cardBrand));
+        if (page == null) return getAllTransactions(spec);
+        return getTransactionsByPage(page, pageSize, spec);
     }
 
-    private TransactionPageData getAllTransactions() {
-        List<Transaction> allTransactions = transactionRepository.findAll();
+    private TransactionPageData getAllTransactions(
+            Specification<Transaction> spec) {
+        List<Transaction> allTransactions = transactionRepository.findAll(spec);
         return new TransactionPageData(allTransactions, 0, 0);
     }
 
-    private TransactionPageData getTransactionsByPage(int page, int pageSize) {
-        int pageIndex = calculatePageIndex(page, pageSize);
-        int pageNumber = pageIndex - 1;
-        Pageable pageable = PageRequest.of(pageNumber, pageSize);
-        Page<Transaction> transactionPage = transactionRepository.findAll(pageable);
+    private TransactionPageData getTransactionsByPage(
+            int page,
+            int pageSize,
+            Specification<Transaction> spec) {
+
+        int pageNumber = calculatePageIndex(page, pageSize);
+        int pageIndex = pageNumber - 1;
+        Pageable pageable = PageRequest.of(pageIndex, pageSize);
+        Page<Transaction> transactionPage = transactionRepository
+                .findAll(spec, pageable);
         return new TransactionPageData(
                 transactionPage.getContent(),
                 transactionPage.getNumber() + 1,

--- a/src/main/java/foi/air/szokpt/transactionmng/services/TransactionService.java
+++ b/src/main/java/foi/air/szokpt/transactionmng/services/TransactionService.java
@@ -34,13 +34,17 @@ public class TransactionService {
             TrxType trxType,
             LocalDateTime before,
             LocalDateTime after,
-            BigDecimal amountGreaterThan) {
+            BigDecimal amountGreaterThan,
+            BigDecimal amountLessThan) {
+
         Specification<Transaction> spec = Specification
                 .where(TransactionSpecs.hasCardBrand(cardBrand))
                 .and(TransactionSpecs.hasTrxType(trxType))
                 .and(TransactionSpecs.beforeDateTime(before))
                 .and(TransactionSpecs.afterDateTime(after)
-                        .and(TransactionSpecs.amountGreaterThan(amountGreaterThan)));
+                        .and(TransactionSpecs.amountGreaterThan(amountGreaterThan))
+                        .and(TransactionSpecs.amountLessThan(amountLessThan))
+                );
         if (page == null) return getAllTransactions(spec);
         return getTransactionsByPage(page, pageSize, spec);
     }

--- a/src/main/java/foi/air/szokpt/transactionmng/services/TransactionService.java
+++ b/src/main/java/foi/air/szokpt/transactionmng/services/TransactionService.java
@@ -31,11 +31,13 @@ public class TransactionService {
             Integer page,
             CardBrand cardBrand,
             TrxType trxType,
-            LocalDateTime before) {
+            LocalDateTime before,
+            LocalDateTime after) {
         Specification<Transaction> spec = Specification
                 .where(TransactionSpecs.hasCardBrand(cardBrand))
                 .and(TransactionSpecs.hasTrxType(trxType))
-                .and(TransactionSpecs.beforeDateTime(before));
+                .and(TransactionSpecs.beforeDateTime(before))
+                .and(TransactionSpecs.afterDateTime(after));
         if (page == null) return getAllTransactions(spec);
         return getTransactionsByPage(page, pageSize, spec);
     }

--- a/src/main/java/foi/air/szokpt/transactionmng/services/TransactionService.java
+++ b/src/main/java/foi/air/szokpt/transactionmng/services/TransactionService.java
@@ -3,6 +3,7 @@ package foi.air.szokpt.transactionmng.services;
 import foi.air.szokpt.transactionmng.dtos.responses.TransactionPageData;
 import foi.air.szokpt.transactionmng.entities.Transaction;
 import foi.air.szokpt.transactionmng.enums.CardBrand;
+import foi.air.szokpt.transactionmng.enums.TrxType;
 import foi.air.szokpt.transactionmng.repositories.TransactionRepository;
 import foi.air.szokpt.transactionmng.specs.TransactionSpecs;
 import org.springframework.data.domain.Page;
@@ -22,9 +23,13 @@ public class TransactionService {
         this.transactionRepository = transactionRepository;
     }
 
-    public TransactionPageData getTransactions(Integer page, CardBrand cardBrand) {
+    public TransactionPageData getTransactions(
+            Integer page,
+            CardBrand cardBrand,
+            TrxType trxType) {
         Specification<Transaction> spec = Specification
-                .where(TransactionSpecs.hasCardBrand(cardBrand));
+                .where(TransactionSpecs.hasCardBrand(cardBrand))
+                .and(TransactionSpecs.hasTrxType(trxType));
         if (page == null) return getAllTransactions(spec);
         return getTransactionsByPage(page, pageSize, spec);
     }

--- a/src/main/java/foi/air/szokpt/transactionmng/specs/TransactionSpecs.java
+++ b/src/main/java/foi/air/szokpt/transactionmng/specs/TransactionSpecs.java
@@ -1,0 +1,16 @@
+package foi.air.szokpt.transactionmng.specs;
+
+import foi.air.szokpt.transactionmng.entities.Transaction;
+import foi.air.szokpt.transactionmng.enums.CardBrand;
+import org.springframework.data.jpa.domain.Specification;
+
+public class TransactionSpecs {
+
+    public static Specification<Transaction> hasCardBrand(CardBrand cardBrand) {
+        return (root, query, builder) ->
+                cardBrand == null ? null : builder.equal(
+                        root.get("cardBrand"), cardBrand
+                );
+    }
+
+}

--- a/src/main/java/foi/air/szokpt/transactionmng/specs/TransactionSpecs.java
+++ b/src/main/java/foi/air/szokpt/transactionmng/specs/TransactionSpecs.java
@@ -45,4 +45,12 @@ public class TransactionSpecs {
                         root.get("amount"), amountGreaterThan
                 );
     }
+
+    public static Specification<Transaction> amountLessThan(
+            BigDecimal amountLessThan) {
+        return (root, query, builder) ->
+                amountLessThan == null ? builder.conjunction() : builder.lessThanOrEqualTo(
+                        root.get("amount"), amountLessThan
+                );
+    }
 }

--- a/src/main/java/foi/air/szokpt/transactionmng/specs/TransactionSpecs.java
+++ b/src/main/java/foi/air/szokpt/transactionmng/specs/TransactionSpecs.java
@@ -5,6 +5,7 @@ import foi.air.szokpt.transactionmng.enums.CardBrand;
 import foi.air.szokpt.transactionmng.enums.TrxType;
 import org.springframework.data.jpa.domain.Specification;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 public class TransactionSpecs {
@@ -34,6 +35,14 @@ public class TransactionSpecs {
         return (root, query, builder) ->
                 after == null ? builder.conjunction() : builder.greaterThanOrEqualTo(
                         root.get("transactionTimestamp"), after
+                );
+    }
+
+    public static Specification<Transaction> amountGreaterThan(
+            BigDecimal amountGreaterThan) {
+        return (root, query, builder) ->
+                amountGreaterThan == null ? builder.conjunction() : builder.greaterThanOrEqualTo(
+                        root.get("amount"), amountGreaterThan
                 );
     }
 }

--- a/src/main/java/foi/air/szokpt/transactionmng/specs/TransactionSpecs.java
+++ b/src/main/java/foi/air/szokpt/transactionmng/specs/TransactionSpecs.java
@@ -5,20 +5,30 @@ import foi.air.szokpt.transactionmng.enums.CardBrand;
 import foi.air.szokpt.transactionmng.enums.TrxType;
 import org.springframework.data.jpa.domain.Specification;
 
+import java.time.LocalDateTime;
+
 public class TransactionSpecs {
 
     public static Specification<Transaction> hasCardBrand(CardBrand cardBrand) {
         return (root, query, builder) ->
-                cardBrand == null ? null : builder.equal(
+                cardBrand == null ? builder.conjunction() : builder.equal(
                         root.get("cardBrand"), cardBrand
                 );
     }
 
     public static Specification<Transaction> hasTrxType(TrxType trxType) {
         return (root, query, builder) ->
-                trxType == null ? null : builder.equal(
+                trxType == null ? builder.conjunction() : builder.equal(
                         root.get("trxType"), trxType
                 );
     }
 
+    public static Specification<Transaction> beforeDateTime(LocalDateTime before) {
+        return (root, query, builder) ->
+                before == null ? builder.conjunction() : builder.lessThanOrEqualTo(
+                        root.get("transactionTimestamp"), before
+                );
+    }
+
+    }
 }

--- a/src/main/java/foi/air/szokpt/transactionmng/specs/TransactionSpecs.java
+++ b/src/main/java/foi/air/szokpt/transactionmng/specs/TransactionSpecs.java
@@ -2,6 +2,7 @@ package foi.air.szokpt.transactionmng.specs;
 
 import foi.air.szokpt.transactionmng.entities.Transaction;
 import foi.air.szokpt.transactionmng.enums.CardBrand;
+import foi.air.szokpt.transactionmng.enums.TrxType;
 import org.springframework.data.jpa.domain.Specification;
 
 public class TransactionSpecs {
@@ -10,6 +11,13 @@ public class TransactionSpecs {
         return (root, query, builder) ->
                 cardBrand == null ? null : builder.equal(
                         root.get("cardBrand"), cardBrand
+                );
+    }
+
+    public static Specification<Transaction> hasTrxType(TrxType trxType) {
+        return (root, query, builder) ->
+                trxType == null ? null : builder.equal(
+                        root.get("trxType"), trxType
                 );
     }
 

--- a/src/main/java/foi/air/szokpt/transactionmng/specs/TransactionSpecs.java
+++ b/src/main/java/foi/air/szokpt/transactionmng/specs/TransactionSpecs.java
@@ -30,5 +30,10 @@ public class TransactionSpecs {
                 );
     }
 
+    public static Specification<Transaction> afterDateTime(LocalDateTime after) {
+        return (root, query, builder) ->
+                after == null ? builder.conjunction() : builder.greaterThanOrEqualTo(
+                        root.get("transactionTimestamp"), after
+                );
     }
 }


### PR DESCRIPTION
Na endpoint za dohvat transakcija se sada mogu slati parametri za filtriranje podataka. Podatke je moguće filtrirati po vrstama kartica (card_brand), po trx_type, po datumu provedbe i po iznosu. Za iznos i datum provedbe moguće je filtrirati po rasponu koristeći parametre amount_greater_than i amount_less_than, odnosno before i after.