### PR TITLE
MI5-84 Endpoint za ažuriranje transakcije

### DIFF
--- a/src/main/java/foi/air/szokpt/transactionmng/controllers/TransactionController.java
+++ b/src/main/java/foi/air/szokpt/transactionmng/controllers/TransactionController.java
@@ -7,14 +7,12 @@ import foi.air.szokpt.transactionmng.enums.CardBrand;
 import foi.air.szokpt.transactionmng.enums.TrxType;
 import foi.air.szokpt.transactionmng.services.TransactionService;
 import foi.air.szokpt.transactionmng.util.ApiResponseUtil;
+import foi.air.szokpt.transactionmng.util.Authorizer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -23,10 +21,12 @@ import java.time.LocalDateTime;
 public class TransactionController {
 
     private final TransactionService transactionService;
+    private final Authorizer authorizer;
 
     @Autowired
-    public TransactionController(TransactionService transactionService) {
+    public TransactionController(TransactionService transactionService, Authorizer authorizer) {
         this.transactionService = transactionService;
+        this.authorizer = authorizer;
     }
 
     @GetMapping("/transactions")
@@ -51,5 +51,17 @@ public class TransactionController {
         Transaction transaction = transactionService.getTransaction(id);
         return ResponseEntity.status(HttpStatus.OK)
                 .body(ApiResponseUtil.successWithData("Transaction successfully fetched", transaction));
+    }
+
+    @PutMapping("transactions/{id}")
+    public ResponseEntity<ApiResponse<Void>> updateTransaction(
+            @PathVariable int id,
+            @RequestHeader("Authorization") String authorizationHeader,
+            @RequestBody Transaction newTransactionData) {
+
+        authorizer.verifyToken(authorizationHeader);
+        transactionService.updateTransaction(id, newTransactionData);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponseUtil.success("Transaction successfully updated."));
     }
 }

--- a/src/main/java/foi/air/szokpt/transactionmng/entities/Transaction.java
+++ b/src/main/java/foi/air/szokpt/transactionmng/entities/Transaction.java
@@ -113,7 +113,7 @@ public class Transaction {
         this.installmentsNumber = installmentsNumber;
     }
 
-    public void setInstallmentsNumber(InstallmentsCreditor installmentsCreditor) {
+    public void setInstallmentsCreditor(InstallmentsCreditor installmentsCreditor) {
         this.installmentsCreditor = installmentsCreditor;
     }
 

--- a/src/main/java/foi/air/szokpt/transactionmng/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/foi/air/szokpt/transactionmng/exceptions/GlobalExceptionHandler.java
@@ -26,4 +26,10 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(ApiResponseUtil.failure("Resource not found"),
                 HttpStatus.NOT_FOUND);
     }
+
+    @ExceptionHandler(ValidationException.class)
+    public ResponseEntity<Object> handleValidationException(ValidationException ex) {
+        return new ResponseEntity<>(ApiResponseUtil.failure(ex.getMessage()),
+                HttpStatus.BAD_REQUEST);
+    }
 }

--- a/src/main/java/foi/air/szokpt/transactionmng/exceptions/ValidationException.java
+++ b/src/main/java/foi/air/szokpt/transactionmng/exceptions/ValidationException.java
@@ -1,0 +1,7 @@
+package foi.air.szokpt.transactionmng.exceptions;
+
+public class ValidationException extends RuntimeException {
+    public ValidationException(String message) {
+        super("Validation failed: " + message);
+    }
+}

--- a/src/main/java/foi/air/szokpt/transactionmng/services/TransactionService.java
+++ b/src/main/java/foi/air/szokpt/transactionmng/services/TransactionService.java
@@ -96,10 +96,8 @@ public class TransactionService {
     }
 
     private void saveTransactionUpdate(Transaction existingTransaction, Transaction newTransactionData){
-        existingTransaction.setCurrency(newTransactionData.getCurrency());
         existingTransaction.setAmount(newTransactionData.getAmount());
         existingTransaction.setTransactionTimestamp(newTransactionData.getTransactionTimestamp());
-        existingTransaction.setCardBrand(newTransactionData.getCardBrand());
         transactionRepository.save(existingTransaction);
     }
 

--- a/src/main/java/foi/air/szokpt/transactionmng/services/TransactionService.java
+++ b/src/main/java/foi/air/szokpt/transactionmng/services/TransactionService.java
@@ -7,8 +7,10 @@ import foi.air.szokpt.transactionmng.enums.TrxType;
 import foi.air.szokpt.transactionmng.exceptions.NotFoundException;
 import foi.air.szokpt.transactionmng.repositories.TransactionRepository;
 import foi.air.szokpt.transactionmng.specs.TransactionSpecs;
+import foi.air.szokpt.transactionmng.util.validation.Validator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -18,15 +20,19 @@ import org.springframework.stereotype.Service;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 public class TransactionService {
     private static final Logger log = LoggerFactory.getLogger(TransactionService.class);
     final int pageSize = 15;
     private final TransactionRepository transactionRepository;
+    private final Validator<Transaction> transactionValidator;
 
-    public TransactionService(TransactionRepository transactionRepository) {
+    public TransactionService(TransactionRepository transactionRepository,
+                              @Qualifier("transactionDataValidator") Validator<Transaction> transactionValidator) {
         this.transactionRepository = transactionRepository;
+        this.transactionValidator = transactionValidator;
     }
 
     public TransactionPageData getTransactions(
@@ -75,6 +81,26 @@ public class TransactionService {
 
     public Transaction getTransaction(int id){
         return transactionRepository.findById(id).orElseThrow(NotFoundException::new);
+    }
+
+    public void updateTransaction(int id, Transaction newTransactionData){
+        Optional<Transaction> optionalExistingTransaction = transactionRepository.findById(id);
+        if(optionalExistingTransaction.isPresent()){
+            newTransactionData.setId(id);
+            transactionValidator.validateData(newTransactionData);
+            Transaction existingTransaction = optionalExistingTransaction.get();
+            saveTransactionUpdate(existingTransaction, newTransactionData);
+        }else{
+            throw new NotFoundException();
+        }
+    }
+
+    private void saveTransactionUpdate(Transaction existingTransaction, Transaction newTransactionData){
+        existingTransaction.setCurrency(newTransactionData.getCurrency());
+        existingTransaction.setAmount(newTransactionData.getAmount());
+        existingTransaction.setTransactionTimestamp(newTransactionData.getTransactionTimestamp());
+        existingTransaction.setCardBrand(newTransactionData.getCardBrand());
+        transactionRepository.save(existingTransaction);
     }
 
     private int calculatePageIndex(int page, int pageSize) {

--- a/src/main/java/foi/air/szokpt/transactionmng/util/Authorizer.java
+++ b/src/main/java/foi/air/szokpt/transactionmng/util/Authorizer.java
@@ -1,0 +1,10 @@
+package foi.air.szokpt.transactionmng.util;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class Authorizer {
+    public void verifyToken(String authenticationHeader){
+
+    }
+}

--- a/src/main/java/foi/air/szokpt/transactionmng/util/validation/TransactionDataValidator.java
+++ b/src/main/java/foi/air/szokpt/transactionmng/util/validation/TransactionDataValidator.java
@@ -1,0 +1,49 @@
+package foi.air.szokpt.transactionmng.util.validation;
+
+import foi.air.szokpt.transactionmng.entities.Transaction;
+import foi.air.szokpt.transactionmng.enums.CardBrand;
+import foi.air.szokpt.transactionmng.exceptions.ValidationException;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Component
+@Qualifier("transactionDataValidator")
+public class TransactionDataValidator implements Validator<Transaction>{
+
+    public void validateData(Transaction transaction){
+        validateRequiredFields(transaction);
+    }
+
+    protected void validateRequiredFields(Transaction transaction){
+        validateField(transaction.getTransactionTimestamp(), "Time and date cannot be null or empty");
+        validateField(transaction.getCardBrand(), "Card brand cannot be null or empty");
+        validateField(transaction.getCurrency(), "Currency cannot be null or empty");
+        validateField(transaction.getAmount(), "Amount cannot be null or empty");
+    }
+
+    private void validateField(String field, String errorMessage){
+        if(field == null || field.isEmpty()){
+            throw new ValidationException(errorMessage);
+        }
+    }
+
+    private void validateField(BigDecimal field, String errorMessage){
+        if(field == null){
+            throw new ValidationException(errorMessage);
+        }
+    }
+
+    private void validateField(CardBrand field, String errorMessage){
+        if(field == null){
+            throw new ValidationException(errorMessage);
+        }
+    }
+    private void validateField(LocalDateTime field, String errorMessage){
+        if(field == null){
+            throw new ValidationException(errorMessage);
+        }
+    }
+}

--- a/src/main/java/foi/air/szokpt/transactionmng/util/validation/TransactionDataValidator.java
+++ b/src/main/java/foi/air/szokpt/transactionmng/util/validation/TransactionDataValidator.java
@@ -1,7 +1,6 @@
 package foi.air.szokpt.transactionmng.util.validation;
 
 import foi.air.szokpt.transactionmng.entities.Transaction;
-import foi.air.szokpt.transactionmng.enums.CardBrand;
 import foi.air.szokpt.transactionmng.exceptions.ValidationException;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
@@ -19,15 +18,7 @@ public class TransactionDataValidator implements Validator<Transaction>{
 
     protected void validateRequiredFields(Transaction transaction){
         validateField(transaction.getTransactionTimestamp(), "Time and date cannot be null or empty");
-        validateField(transaction.getCardBrand(), "Card brand cannot be null or empty");
-        validateField(transaction.getCurrency(), "Currency cannot be null or empty");
         validateField(transaction.getAmount(), "Amount cannot be null or empty");
-    }
-
-    private void validateField(String field, String errorMessage){
-        if(field == null || field.isEmpty()){
-            throw new ValidationException(errorMessage);
-        }
     }
 
     private void validateField(BigDecimal field, String errorMessage){
@@ -36,11 +27,6 @@ public class TransactionDataValidator implements Validator<Transaction>{
         }
     }
 
-    private void validateField(CardBrand field, String errorMessage){
-        if(field == null){
-            throw new ValidationException(errorMessage);
-        }
-    }
     private void validateField(LocalDateTime field, String errorMessage){
         if(field == null){
             throw new ValidationException(errorMessage);

--- a/src/main/java/foi/air/szokpt/transactionmng/util/validation/Validator.java
+++ b/src/main/java/foi/air/szokpt/transactionmng/util/validation/Validator.java
@@ -1,0 +1,5 @@
+package foi.air.szokpt.transactionmng.util.validation;
+
+public interface Validator<T> {
+    void validateData(T object);
+}


### PR DESCRIPTION
Transakcija se ažurira slanjem PUT zahtjeva na "transactions/{id}".  Ažuriraju se samo odabrani atributi, to su za sad: CardType, amount, currency i transactionTimestamp. Prije unosa se ti atributi validiraju, a zatim se transakciji ažuriraju navedeni podaci. Pri neuspješnoj validaciji poziva se ValidationExcdption i vraća se statusni kod 400. Dodan je i mock Authorizer u kojem će kasnije biti logika provjere valjanosti jwt tokena. 